### PR TITLE
Gerador-de-CPF #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ venv
 db.sqlite3
 .vscode
 beta.js
+bin
+lib

--- a/cpf_api/cpf.py
+++ b/cpf_api/cpf.py
@@ -59,7 +59,8 @@ class CPF:
         cpf = ''.join([str(x) for x in cpf])
         return {
             0: cpf,
-            1: self.formatar_cpf(cpf)
+            1: self.formatar_cpf(cpf),
+            2: estado
         }
 
     def formatar_cpf(self, cpf):

--- a/cpf_gui/static/css/style.css
+++ b/cpf_gui/static/css/style.css
@@ -29,6 +29,25 @@ body {
     padding: 5vh;
 }
 
+    .container input,
+    .container select {
+        margin: 10px;
+    }
+
+    .container .row {
+        display: flex;
+        justify-content: center;
+        }
+        
+    .container button {
+    margin: 10px;
+    }
+
+    .container .full-width {
+    width: calc(100% - 6px); /* Subtract padding */
+    padding: 0 3px;
+    }
+
 .content-box {
     padding: 1.5vh;
     width: 30vw;

--- a/cpf_gui/static/js/script.js
+++ b/cpf_gui/static/js/script.js
@@ -1,8 +1,11 @@
 var cpfData = ["00000000000","000.000.000-00"]
 document.getElementById("cpf-box").value = cpfData[0]
+var estado;
 
 const gerarCpf = () => {
-    fetch("http://127.0.0.1:8000/api/cpf/gerar/")
+    var select = document.getElementById("estados");
+    estado = select.options[select.selectedIndex].value;
+    fetch(`http://127.0.0.1:8000/api/cpf/gerar/?estado=${estado}`)
     .then(response => {
         if(!response.ok) {
             throw new Error("Erro na requisição")

--- a/cpf_gui/templates/cpf_gui/index.html
+++ b/cpf_gui/templates/cpf_gui/index.html
@@ -15,10 +15,34 @@
         <div class="content-box">
             <input type="text" class="cpf-box" id="cpf-box">
             <select class="cpf-box" name="estados" id="estados">
-                <option value="RS">RS</option>
-                <option value="SP">SP</option>
-                <option value="RN">RN</option>
+                <option value="">Padrão</option>
+                <option value="AC">AC</option>
+                <option value="AL">AL</option>
+                <option value="AM">AM</option>
+                <option value="AP">AP</option>
+                <option value="BA">BA</option>
+                <option value="CE">CE</option>
+                <option value="DF">DF</option>
+                <option value="ES">ES</option>
+                <option value="GO">GO</option>
+                <option value="MA">MA</option>
+                <option value="MG">MG</option>
+                <option value="MS">MS</option>
+                <option value="MT">MT</option>
+                <option value="PA">PA</option>
+                <option value="PB">PB</option>
+                <option value="PE">PE</option>
+                <option value="PI">PI</option>
                 <option value="PR">PR</option>
+                <option value="RJ">RJ</option>
+                <option value="RN">RN</option>
+                <option value="RO">RO</option>
+                <option value="RR">RR</option>
+                <option value="RS">RS</option>
+                <option value="SC">SC</option>
+                <option value="SE">SE</option>
+                <option value="SP">SP</option>
+                <option value="TO">TO</option>
             </select>
         </div>
         <div class="container">

--- a/cpf_gui/templates/cpf_gui/index.html
+++ b/cpf_gui/templates/cpf_gui/index.html
@@ -14,13 +14,19 @@
     <div class="container">
         <div class="content-box">
             <input type="text" class="cpf-box" id="cpf-box">
+            <select class="cpf-box" name="estados" id="estados">
+                <option value="RS">RS</option>
+                <option value="SP">SP</option>
+                <option value="RN">RN</option>
+                <option value="PR">PR</option>
+            </select>
         </div>
-        <div class="content-box">
-            <input type="button" class="btn-sec" value="Formatar CPF" onclick="formatarCpf()">
-            <input type="button" class="btn-sec" value="Validar CPF" onclick="validarCpf()">
-        </div>
-        <div class="content-box">
-            <input type="button" class="btn-pri" value="Gerar CPF" onclick="gerarCpf()">
+        <div class="container">
+            <div class="row">
+                <input type="button" class="btn-sec" value="Formatar CPF" onclick="formatarCpf()"/>
+                <input type="button" class="btn-sec" value="Validar CPF" onclick="validarCpf()"/>
+            </div>
+            <input type="button" class="btn-pri full-width" value="Gerar CPF" onclick="gerarCpf()"/>
         </div>
     </div>
     <script src="{% static 'js/script.js' %}"></script>


### PR DESCRIPTION
#1: **Lista de melhorias**

- Adicionado itens para serem ignorados em`.gitignore`
- Adicionado recurso que permite o usuário escolher o estado do CPF para ser gerado
- Adicionado estilo do input que seleciona o estado (UF) do CPF
- Adicionado "Estado" no retorno da função `gerar_cpf` na `API`
- Mudanças na função `gerarCpf` em `js/script.js`
- Mudanças na página inicial